### PR TITLE
Fix: Use dynamic controllers and improve caching.

### DIFF
--- a/unifi-portal/src/api/controllers/UnifiPortalController.php
+++ b/unifi-portal/src/api/controllers/UnifiPortalController.php
@@ -48,44 +48,14 @@ class UnifiPortalController
                 );
 
                 $controller_data[] = [
-                    "name" => esc_html($controller_name),
-                    "key" => Utils::xorEncrypt(strval($controller_id)),
+                    "name" => esc_html($controller_name ?: $controller->post_title),
+                    "key" => esc_html($controller->post_name),
                 ];
             }
 
-            $controllers_static = [
-                "controllers" => [
-                    [
-                        "name" => "Thundering Surf UDM-Pro",
-                        "key" => "4g==",
-                        "system" => "modern",
-                        "sites" => ["default"],
-                    ],
-                    [
-                        "name" => "SBSNJ",
-                        "key" => "4w==",
-                        "system" => "legacy",
-                        "sites" => [
-                            "default",
-                            "d6xnexrb",
-                            "xzethxa3",
-                            "a07ukd7h",
-                            "15tatef9",
-                            "lwjr3rse"
-                        ],
-                    ],
-                    [
-                        "name" => "Sea Shelll Resort",
-                        "key" => "6ws=",
-                        "system" => "modern",
-                        "sites" => ["default"],
-                    ],
-                ],
-            ];
-
             return [
                 "status" => "success",
-                "data" => ["controllers" => $controllers_static],
+                "data" => ["controllers" => $controller_data],
             ];
         } catch (\Exception $e) {
             return [


### PR DESCRIPTION
- Modified UnifiPortalController::fetchControllers to return controllers configured in WordPress admin instead of a hardcoded list. This resolves the issue where newly added controllers were not appearing in the UI.
- Implemented cache invalidation for 'unifi_controller_posts' transient. The cache is now cleared when a 'unifi-controller' post is saved or deleted, ensuring timely updates to the controller list.
- The 'key' field for controllers sent to the frontend now uses the post slug.